### PR TITLE
fix: module directory detection

### DIFF
--- a/gen-wiki.py
+++ b/gen-wiki.py
@@ -212,7 +212,10 @@ if __name__ == "__main__":
         process_environment(directory, config, args.output_dir)
 
     md_files = list_md_files(args.output_dir)
-    create_modules_documentation(args.output_dir)
-    md_files += list_md_files(args.output_dir)
+    try :
+        create_modules_documentation(args.output_dir)
+        md_files += list_md_files(args.output_dir)
+    except Exception as e:
+        print(f"Error creating modules documentation: {e}")
     os.chdir("../..")
     copy_wiki(md_files)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
Adding some check for the module documentation creation to test if the directory exist

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[1354](https://github.com/skyscrapers/platform/issues/1354)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/coding_guidelines/git/#pull-requests)
- [x] My code has been tested: 
  - [x] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [ ] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
